### PR TITLE
Fix "unknown option: --wrap=memcpy" error on macOS

### DIFF
--- a/tools/zapcc/CMakeLists.txt
+++ b/tools/zapcc/CMakeLists.txt
@@ -1,5 +1,7 @@
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -Wl,--wrap=memcpy")
+  if(NOT APPLE)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -Wl,--wrap=memcpy")
+  endif()
 endif ()
 
 if (ZAPCC_DEBUG)

--- a/tools/zapccs/CMakeLists.txt
+++ b/tools/zapccs/CMakeLists.txt
@@ -1,7 +1,9 @@
 # zapccs
 if (LLVM_COMPILER_IS_GCC_COMPATIBLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-common -Woverloaded-virtual -fno-strict-aliasing -pedantic")
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -Wl,--wrap=memcpy")
+  if(NOT APPLE)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -Wl,--wrap=memcpy")
+  endif()
 endif ()
 
 include_directories(BEFORE


### PR DESCRIPTION
After these changes everything builds without a hitch on Xcode 9.4.