### PR TITLE
Use GitHub Actions to build binaries

### DIFF
--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -8,10 +8,10 @@ on:
 jobs:
   build_Linux:
     name: Ubuntu build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       name: Checkout repository
     - name: Get Env
       run: |
@@ -27,43 +27,42 @@ jobs:
         df -h
         ls -kahl
         export cwd=$PWD
+        export build_dir=$PWD/$(mktemp -d build-$(date +%F_%H.%M.%S)-XXXXX)
         export ACCEPT_EULA=Y
-    - name: Install Ninja, CMake, and co. 
+    - name: Install ninja, ocaml, and co. 
     # actually, all but ninja should be installed - see https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#ubuntu-1804-lts
+    # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu2004-README.md
     # sudo apt-get upgrade -y # do not run upgrade on all outdated packages...
       run: |
         sudo apt-get update
-        sudo apt-get install -y git curl build-essential ninja-build python python3-pip ocaml
+        sudo apt-get install -y ninja-build ocaml
         sudo pip3 install pygments pyyaml
-        mkdir -pv /tmp/cmake && cd /tmp/cmake
-        curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
-        export PATH=/tmp/cmake/bin:$PATH
     - name: Configure and build
       run: |
-        mkdir -pv /tmp/build && cd /tmp/build
+        cd $build_dir
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
         ninja
     - name: Run all tests
       run: |
-        mkdir -pv /tmp/tests && cd /tmp/build
-        ninja check-all 2>&1 | tee /tmp/tests/check-all.log
+        mkdir -pv $build_dir/tests && cd $build_dir
+        ninja check-all 2>&1 | tee $build_dir/tests/check-all.log
     - name: Publish artifacts (i.e. binaries after compilation)
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with: 
         name: Ubuntu_build
-        path: /tmp/build
-    - name: Publish test results
-      uses: actions/upload-artifact@v1
-      with: 
-        name: Ubuntu_tests
-        path: /tmp/tests
+        path: $build_dir
+    # - name: Publish test results
+    #   uses: actions/upload-artifact@v2
+    #   with: 
+    #     name: Ubuntu_tests
+    #     path: $build_dir/tests
 
   build_macOS:
     name: macOS build 
     runs-on: macOS-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         name: Checkout repository
       - name: Get Env
         run: |
@@ -75,29 +74,30 @@ jobs:
           system_profiler -timeout 30 -detailLevel basic
           df -h
           ls -kahl
+          export build_dir=$PWD/$(mktemp -d build-$(date +%F_%H.%M.%S)-XXXXX)
           export cwd=$PWD
-      - name: Install CMake and Ninja
+      - name: Install ninja and ocaml
         run: |
-          brew install cmake ninja ocaml
-          pip install pygments pyyaml
+          brew install ninja ocaml
+          pip3 install pygments pyyaml
           export CC=$(which clang)
           export CXX=$(which clang++)
       - name: Configure and build
         run: |
-          mkdir -pv /tmp/build && cd /tmp/build
+          mkdir -pv $build_dir && cd $build_dir
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
           ninja
       - name: Run all checks
         run: |
-          mkdir -pv /tmp/tests && cd /tmp/build
-          ninja check-all 2>&1 | tee /tmp/tests/check-all.log
+          mkdir -pv $build_dir/tests && cd $build_dir
+          ninja check-all 2>&1 | tee $build_dir/tests/check-all.log
       - name: Publish artifacts (i.e. binaries after compilation)
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with: 
           name: macOS_build
-          path: /tmp/build
-      - name: Publish test results
-        uses: actions/upload-artifact@v1
-        with: 
-          name: macOS_tests
-          path: /tmp/tests
+          path: $build_dir
+      # - name: Publish test results
+      #   uses: actions/upload-artifact@v2
+      #   with: 
+      #     name: macOS_tests
+      #     path: $build_dir/tests

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -30,7 +30,8 @@ jobs:
     # sudo apt-get upgrade -y # do not run upgrade on all outdated packages...
       run: |
         sudo apt-get update
-        sudo apt-get install -y git curl build-essential ninja-build python python3
+        sudo apt-get install -y git curl build-essential ninja-build python python3-pip ocaml
+        sudo pip3 install pygments pyyaml
         mkdir -pv /opt/cmake && cd /opt/cmake
         curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
         export PATH=/opt/cmake/bin:$PATH
@@ -67,7 +68,8 @@ jobs:
           export cwd=$PWD
       - name: Install CMake and Ninja
         run: |
-          brew install cmake ninja
+          brew install cmake ninja ocaml
+          pip install pygments pyyaml
           export CC=$(which clang)
           export CXX=$(which clang++)
       - name: Configure and build

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -32,21 +32,28 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y git curl build-essential ninja-build python python3-pip ocaml
         sudo pip3 install pygments pyyaml
-        mkdir -pv /opt/cmake && cd /opt/cmake
+        mkdir -pv /tmp/cmake && cd /tmp/cmake
         curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
-        export PATH=/opt/cmake/bin:$PATH
+        export PATH=/tmp/cmake/bin:$PATH
     - name: Configure and build
       run: |
-        mkdir -pv /opt/build && cd /opt/build
+        mkdir -pv /tmp/build && cd /tmp/build
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
         ninja
+    - name: Run all tests
+      run: |
+        mkdir -pv /tmp/tests
+        ninja check-all 2>&1 | tee /tmp/tests/check-all.log
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v1
       with: 
         name: Ubuntu_build
-        path: /opt/build
-    - name: Run all checks
-      run: ninja check-all
+        path: /tmp/build
+    - name: Publish test results
+      uses: actions/upload-artifact@v1
+      with: 
+        name: Ubuntu_tests
+        path: /tmp/tests
 
   build_macOS:
     name: macOS build 
@@ -77,10 +84,17 @@ jobs:
           mkdir -pv /tmp/build && cd /tmp/build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
           ninja
+      - name: Run all checks
+        run: |
+          mkdir -pv /tmp/tests
+          ninja check-all 2>&1 | tee /tmp/tests/check-all.log
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v1
         with: 
           name: macOS_build
           path: /tmp/build
-      - name: Run all checks
-        run: ninja check-all
+      - name: Publish test results
+        uses: actions/upload-artifact@v1
+        with: 
+          name: macOS_tests
+          path: /tmp/tests

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -39,12 +39,13 @@ jobs:
         mkdir -pv /opt/build && cd /opt/build
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
         ninja
-        ninja check-all
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v1
       with: 
         name: Ubuntu_build
-        path: /opt/build       
+        path: /opt/build
+    - name: Run all checks
+      run: ninja check-all
 
   build_macOS:
     name: macOS build 
@@ -74,9 +75,10 @@ jobs:
           mkdir -pv /tmp/build && cd /tmp/build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
           ninja
-          ninja check-all
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v1
         with: 
           name: macOS_build
-          path: /tmp/build  
+          path: /tmp/build
+      - name: Run all checks
+        run: ninja check-all

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -1,0 +1,81 @@
+name: build_binaries_on_release_branch_push
+
+on:
+  push:
+    branches: 
+      - release/*
+
+jobs:
+  build_Linux:
+    name: Build binary for Ubuntu-latest
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+      name: Checkout repository
+    - name: Get Env
+      run: |
+        env
+        set
+        uname -a
+        cat /etc/*release*
+        nproc
+        free -h
+        df -h
+        ls -kahl
+        export cwd=$PWD
+    - name: Install Ninja, CMake, and co. 
+    # actually, all but ninja should be installed - see https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#ubuntu-1804-lts
+      run: |
+        apt update
+        apt upgrade -y
+        apt install -y git curl build-essential ninja-build python python3
+        mkdir -pv /opt/cmake && cd /opt/cmake
+        curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
+        export PATH=/opt/cmake/bin:$PATH
+    - name: Configure and build
+      run: |
+        mkdir -pv /opt/build && cd /opt/build
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
+        ninja
+        ninja check-all
+    - name: Publish artifacts (i.e. binaries after compilation)
+      uses: actions/upload-artifact@v1
+      with: 
+        name: Binary for Ubuntu-latest
+        path: /opt/build       
+
+  build_macOS:
+    name: Build binary for macOS
+    runs-on: macOS-latest
+
+    steps:
+      - uses: actions/checkout@v1
+        name: Checkout repository
+      - name: Get Env
+        run: |
+          env
+          set
+          uname -a
+          sw_vers
+          xcodebuild -version
+          nproc
+          df -h
+          ls -kahl
+          export cwd=$PWD
+      - name: Install CMake and Ninja
+        run: |
+          brew install cmake ninja
+          export CC=$(which clang)
+          export CXX=$(which clang++)
+      - name: Configure and build
+        run: |
+          mkdir -pv /opt/build && cd /opt/build
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
+          ninja
+          ninja check-all
+      - name: Publish artifacts (i.e. binaries after compilation)
+        uses: actions/upload-artifact@v1
+        with: 
+          name: Binary for macOS-latest
+          path: /opt/build  

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -19,7 +19,10 @@ jobs:
         set
         uname -a
         cat /etc/*release*
+        lscpu
         echo "nproc=$(nproc)"
+        sudo dmidecode
+        lsmem
         free -h
         df -h
         ls -kahl

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -24,11 +24,12 @@ jobs:
         df -h
         ls -kahl
         export cwd=$PWD
+        export ACCEPT_EULA=Y
     - name: Install Ninja, CMake, and co. 
     # actually, all but ninja should be installed - see https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#ubuntu-1804-lts
+    # sudo apt-get upgrade -y # do not run upgrade on all outdated packages...
       run: |
         sudo apt-get update
-        sudo apt-get upgrade -y
         sudo apt-get install -y git curl build-essential ninja-build python python3
         mkdir -pv /opt/cmake && cd /opt/cmake
         curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
@@ -59,6 +60,7 @@ jobs:
           uname -a
           sw_vers
           xcodebuild -version
+          system_profiler -timeout 30 -detailLevel basic
           df -h
           ls -kahl
           export cwd=$PWD
@@ -69,7 +71,7 @@ jobs:
           export CXX=$(which clang++)
       - name: Configure and build
         run: |
-          mkdir -pv /opt/build && cd /opt/build
+          mkdir -pv /tmp/build && cd /tmp/build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
           ninja
           ninja check-all
@@ -77,4 +79,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with: 
           name: macOS_build
-          path: /opt/build  
+          path: /tmp/build  

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_Linux:
-    name: Build binary for Ubuntu-latest
+    name: Ubuntu build
     runs-on: ubuntu-latest
     
     steps:
@@ -19,7 +19,7 @@ jobs:
         set
         uname -a
         cat /etc/*release*
-        nproc
+        echo "nproc=$(nproc)"
         free -h
         df -h
         ls -kahl
@@ -27,9 +27,9 @@ jobs:
     - name: Install Ninja, CMake, and co. 
     # actually, all but ninja should be installed - see https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#ubuntu-1804-lts
       run: |
-        apt update
-        apt upgrade -y
-        apt install -y git curl build-essential ninja-build python python3
+        sudo apt-get update
+        sudo apt-get upgrade -y
+        sudo apt-get install -y git curl build-essential ninja-build python python3
         mkdir -pv /opt/cmake && cd /opt/cmake
         curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
         export PATH=/opt/cmake/bin:$PATH
@@ -42,11 +42,11 @@ jobs:
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v1
       with: 
-        name: Binary for Ubuntu-latest
+        name: Ubuntu_build
         path: /opt/build       
 
   build_macOS:
-    name: Build binary for macOS
+    name: macOS build 
     runs-on: macOS-latest
 
     steps:
@@ -59,7 +59,6 @@ jobs:
           uname -a
           sw_vers
           xcodebuild -version
-          nproc
           df -h
           ls -kahl
           export cwd=$PWD
@@ -77,5 +76,5 @@ jobs:
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v1
         with: 
-          name: Binary for macOS-latest
+          name: macOS_build
           path: /opt/build  

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -45,7 +45,7 @@ jobs:
         ninja
     - name: Run all tests
       run: |
-        mkdir -pv /tmp/tests
+        mkdir -pv /tmp/tests && cd /tmp/build
         ninja check-all 2>&1 | tee /tmp/tests/check-all.log
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v1
@@ -89,7 +89,7 @@ jobs:
           ninja
       - name: Run all checks
         run: |
-          mkdir -pv /tmp/tests
+          mkdir -pv /tmp/tests && cd /tmp/build
           ninja check-all 2>&1 | tee /tmp/tests/check-all.log
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v1


### PR DESCRIPTION
Hello,

this is similar to https://github.com/yrnkrn/zapcc/pull/31 and https://github.com/yrnkrn/zapcc/pull/30, except that it is using the [free (beta) GitHub Actions workflows](https://github.com/features/actions) – see also this [Overview on Automating your workflow with GitHub Actions](https://help.github.com/en/categories/automating-your-workflow-with-github-actions)

You currently have to [sign up](https://github.com/features/actions/signup/?account=yrnkrn) to enable beta access.

The yaml file in the PR is configured to trigger the workflow (i.e. currently the builds for Ubuntu Linux and macOS) only on push events to branches captured by `release/*` - feel free to change that however you see fit (e.g. all push events and also pull requests)

The tests did not all pass in my trial runs, there may be some more work necessary to capture the output of the `ninja check-all` run.

Windows would also be available as one of the [Supported virtual environments and hardware resources](https://help.github.com/en/articles/virtual-environments-for-github-actions#supported-virtual-environments-and-hardware-resources)

I have not tested the binaries as I was mainly trying to get the workflows to run, you can find the uploaded artifacts in the top right corner of the respective workflows (see image) - [link to example workflow with artifacts](https://github.com/kramred/zapcc/commit/034e1ad7e7d12c1eaca30de07ec3396defa23310/checks?check_suite_id=256114198)


![github_com_kramred_zapcc_commit_034e1ad7e7d12c1eaca30de07ec3396defa23310_checks_check_suite_id_256114198_Laptop_with_MDPI_screen_](https://user-images.githubusercontent.com/16719551/66410851-b6ccb980-e9ea-11e9-86fc-f31bd8b1e6ef.png)

Also, it currently publishes the whole `build` folder, which might be a bit too much.

~
Mark
