### PR TITLE
refined GitHub Actions file to build binaries

### DIFF
--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -8,10 +8,10 @@ on:
 jobs:
   build_Linux:
     name: Ubuntu build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       name: Checkout repository
     - name: Get Env
       run: |
@@ -27,43 +27,42 @@ jobs:
         df -h
         ls -kahl
         export cwd=$PWD
+        export build_dir=$PWD/$(mktemp -d build-$(date +%F_%H.%M.%S)-XXXXX)
         export ACCEPT_EULA=Y
-    - name: Install Ninja, CMake, and co. 
+    - name: Install ninja, ocaml, and co. 
     # actually, all but ninja should be installed - see https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#ubuntu-1804-lts
+    # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu2004-README.md
     # sudo apt-get upgrade -y # do not run upgrade on all outdated packages...
       run: |
         sudo apt-get update
-        sudo apt-get install -y git curl build-essential ninja-build python python3-pip ocaml
+        sudo apt-get install -y ninja-build ocaml
         sudo pip3 install pygments pyyaml
-        mkdir -pv /tmp/cmake && cd /tmp/cmake
-        curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
-        export PATH=/tmp/cmake/bin:$PATH
     - name: Configure and build
       run: |
-        mkdir -pv /tmp/build && cd /tmp/build
+        cd $build_dir
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
         ninja
     - name: Run all tests
       run: |
-        mkdir -pv /tmp/tests && cd /tmp/build
-        ninja check-all 2>&1 | tee /tmp/tests/check-all.log
+        mkdir -pv $build_dir/tests && cd $build_dir
+        ninja check-all 2>&1 | tee $build_dir/tests/check-all.log
     - name: Publish artifacts (i.e. binaries after compilation)
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with: 
         name: Ubuntu_build
-        path: /tmp/build
-    - name: Publish test results
-      uses: actions/upload-artifact@v1
-      with: 
-        name: Ubuntu_tests
-        path: /tmp/tests
+        path: $build_dir
+    # - name: Publish test results
+    #   uses: actions/upload-artifact@v2
+    #   with: 
+    #     name: Ubuntu_tests
+    #     path: $build_dir/tests
 
   build_macOS:
     name: macOS build 
     runs-on: macOS-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         name: Checkout repository
       - name: Get Env
         run: |
@@ -75,29 +74,30 @@ jobs:
           system_profiler -timeout 30 -detailLevel basic
           df -h
           ls -kahl
+          export build_dir=$PWD/$(mktemp -d build-$(date +%F_%H.%M.%S)-XXXXX)
           export cwd=$PWD
-      - name: Install CMake and Ninja
+      - name: Install ninja and ocaml
         run: |
-          brew install cmake ninja ocaml
-          pip install pygments pyyaml
+          brew install ninja ocaml
+          pip3 install pygments pyyaml
           export CC=$(which clang)
           export CXX=$(which clang++)
       - name: Configure and build
         run: |
-          mkdir -pv /tmp/build && cd /tmp/build
+          mkdir -pv $build_dir && cd $build_dir
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
           ninja
       - name: Run all checks
         run: |
-          mkdir -pv /tmp/tests && cd /tmp/build
-          ninja check-all 2>&1 | tee /tmp/tests/check-all.log
+          mkdir -pv $build_dir/tests && cd $build_dir
+          ninja check-all 2>&1 | tee $build_dir/tests/check-all.log
       - name: Publish artifacts (i.e. binaries after compilation)
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with: 
           name: macOS_build
-          path: /tmp/build
-      - name: Publish test results
-        uses: actions/upload-artifact@v1
-        with: 
-          name: macOS_tests
-          path: /tmp/tests
+          path: $build_dir
+      # - name: Publish test results
+      #   uses: actions/upload-artifact@v2
+      #   with: 
+      #     name: macOS_tests
+      #     path: $build_dir/tests

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -30,7 +30,8 @@ jobs:
     # sudo apt-get upgrade -y # do not run upgrade on all outdated packages...
       run: |
         sudo apt-get update
-        sudo apt-get install -y git curl build-essential ninja-build python python3
+        sudo apt-get install -y git curl build-essential ninja-build python python3-pip ocaml
+        sudo pip3 install pygments pyyaml
         mkdir -pv /opt/cmake && cd /opt/cmake
         curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
         export PATH=/opt/cmake/bin:$PATH
@@ -67,7 +68,8 @@ jobs:
           export cwd=$PWD
       - name: Install CMake and Ninja
         run: |
-          brew install cmake ninja
+          brew install cmake ninja ocaml
+          pip install pygments pyyaml
           export CC=$(which clang)
           export CXX=$(which clang++)
       - name: Configure and build

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -32,21 +32,28 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y git curl build-essential ninja-build python python3-pip ocaml
         sudo pip3 install pygments pyyaml
-        mkdir -pv /opt/cmake && cd /opt/cmake
+        mkdir -pv /tmp/cmake && cd /tmp/cmake
         curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
-        export PATH=/opt/cmake/bin:$PATH
+        export PATH=/tmp/cmake/bin:$PATH
     - name: Configure and build
       run: |
-        mkdir -pv /opt/build && cd /opt/build
+        mkdir -pv /tmp/build && cd /tmp/build
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
         ninja
+    - name: Run all tests
+      run: |
+        mkdir -pv /tmp/tests
+        ninja check-all 2>&1 | tee /tmp/tests/check-all.log
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v1
       with: 
         name: Ubuntu_build
-        path: /opt/build
-    - name: Run all checks
-      run: ninja check-all
+        path: /tmp/build
+    - name: Publish test results
+      uses: actions/upload-artifact@v1
+      with: 
+        name: Ubuntu_tests
+        path: /tmp/tests
 
   build_macOS:
     name: macOS build 
@@ -77,10 +84,17 @@ jobs:
           mkdir -pv /tmp/build && cd /tmp/build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
           ninja
+      - name: Run all checks
+        run: |
+          mkdir -pv /tmp/tests
+          ninja check-all 2>&1 | tee /tmp/tests/check-all.log
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v1
         with: 
           name: macOS_build
           path: /tmp/build
-      - name: Run all checks
-        run: ninja check-all
+      - name: Publish test results
+        uses: actions/upload-artifact@v1
+        with: 
+          name: macOS_tests
+          path: /tmp/tests

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -39,12 +39,13 @@ jobs:
         mkdir -pv /opt/build && cd /opt/build
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
         ninja
-        ninja check-all
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v1
       with: 
         name: Ubuntu_build
-        path: /opt/build       
+        path: /opt/build
+    - name: Run all checks
+      run: ninja check-all
 
   build_macOS:
     name: macOS build 
@@ -74,9 +75,10 @@ jobs:
           mkdir -pv /tmp/build && cd /tmp/build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
           ninja
-          ninja check-all
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v1
         with: 
           name: macOS_build
-          path: /tmp/build  
+          path: /tmp/build
+      - name: Run all checks
+        run: ninja check-all

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build_Linux:
+    continue-on-error: true
     name: Ubuntu build
     runs-on: ubuntu-20.04
     
@@ -42,7 +43,9 @@ jobs:
         cd $RUNNER_WORKSPACE/build
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF $GITHUB_WORKSPACE
         ninja
+        du -hs ./
         cd .. && tar -c -I lbzip2 -f $GITHUB_WORKSPACE/github-actions-build-ubuntu-20.04.tar.bz2 ./build
+        ls -hl $GITHUB_WORKSPACE/github-actions-build-ubuntu-20.04.tar.bz2
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v2
       with: 
@@ -61,6 +64,7 @@ jobs:
         path: check-all-ubuntu-20.04.log
 
   build_macOS:
+    continue-on-error: true
     name: macOS build 
     runs-on: macOS-latest
 
@@ -91,7 +95,9 @@ jobs:
           cd $RUNNER_WORKSPACE/build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF $GITHUB_WORKSPACE
           ninja
-          cd .. && tar -c -I lbzip2 -f $GITHUB_WORKSPACE/github-actions-build-macOS.tar.bz2 ./build
+          du -hs ./
+          cd .. && gtar -c -I lbzip2 -f $GITHUB_WORKSPACE/github-actions-build-macOS.tar.bz2 ./build
+          ls -hl $GITHUB_WORKSPACE/github-actions-build-macOS.tar.bz2
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v2
         with: 

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -1,0 +1,81 @@
+name: build_binaries_on_release_branch_push
+
+on:
+  push:
+    branches: 
+      - release/*
+
+jobs:
+  build_Linux:
+    name: Build binary for Ubuntu-latest
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+      name: Checkout repository
+    - name: Get Env
+      run: |
+        env
+        set
+        uname -a
+        cat /etc/*release*
+        nproc
+        free -h
+        df -h
+        ls -kahl
+        export cwd=$PWD
+    - name: Install Ninja, CMake, and co. 
+    # actually, all but ninja should be installed - see https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#ubuntu-1804-lts
+      run: |
+        apt update
+        apt upgrade -y
+        apt install -y git curl build-essential ninja-build python python3
+        mkdir -pv /opt/cmake && cd /opt/cmake
+        curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
+        export PATH=/opt/cmake/bin:$PATH
+    - name: Configure and build
+      run: |
+        mkdir -pv /opt/build && cd /opt/build
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
+        ninja
+        ninja check-all
+    - name: Publish artifacts (i.e. binaries after compilation)
+      uses: actions/upload-artifact@v1
+      with: 
+        name: Binary for Ubuntu-latest
+        path: /opt/build       
+
+  build_macOS:
+    name: Build binary for macOS
+    runs-on: macOS-latest
+
+    steps:
+      - uses: actions/checkout@v1
+        name: Checkout repository
+      - name: Get Env
+        run: |
+          env
+          set
+          uname -a
+          sw_vers
+          xcodebuild -version
+          nproc
+          df -h
+          ls -kahl
+          export cwd=$PWD
+      - name: Install CMake and Ninja
+        run: |
+          brew install cmake ninja
+          export CC=$(which clang)
+          export CXX=$(which clang++)
+      - name: Configure and build
+        run: |
+          mkdir -pv /opt/build && cd /opt/build
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
+          ninja
+          ninja check-all
+      - name: Publish artifacts (i.e. binaries after compilation)
+        uses: actions/upload-artifact@v1
+        with: 
+          name: Binary for macOS-latest
+          path: /opt/build  

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -19,7 +19,10 @@ jobs:
         set
         uname -a
         cat /etc/*release*
+        lscpu
         echo "nproc=$(nproc)"
+        sudo dmidecode
+        lsmem
         free -h
         df -h
         ls -kahl

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -42,17 +42,17 @@ jobs:
         cd $RUNNER_WORKSPACE/build
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF $GITHUB_WORKSPACE
         ninja
+    - name: Publish artifacts (i.e. binaries after compilation)
+      uses: actions/upload-artifact@v2
+      with: 
+        name: Ubuntu_build
+        path: $RUNNER_WORKSPACE/build
     - name: Run all tests
       run: |
         echo ======{,,," Run all tests ",,,}
         mkdir -pv $RUNNER_WORKSPACE/tests
         cd $RUNNER_WORKSPACE/build/
         ninja check-all 2>&1 | tee $RUNNER_WORKSPACE/tests/check-all.log
-    - name: Publish artifacts (i.e. binaries after compilation)
-      uses: actions/upload-artifact@v2
-      with: 
-        name: Ubuntu_build
-        path: $RUNNER_WORKSPACE/build
     - name: Publish test results
       uses: actions/upload-artifact@v2
       with: 
@@ -90,17 +90,17 @@ jobs:
           cd $RUNNER_WORKSPACE/build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF $GITHUB_WORKSPACE
           ninja
+      - name: Publish artifacts (i.e. binaries after compilation)
+        uses: actions/upload-artifact@v2
+        with: 
+          name: macOS_build
+          path: $RUNNER_WORKSPACE/build
       - name: Run all checks
         run: |
           echo ======{,,," Run all tests ",,,}
           mkdir -pv $RUNNER_WORKSPACE/tests
           cd $RUNNER_WORKSPACE/build
           ninja check-all 2>&1 | tee $RUNNER_WORKSPACE/tests/check-all.log
-      - name: Publish artifacts (i.e. binaries after compilation)
-        uses: actions/upload-artifact@v2
-        with: 
-          name: macOS_build
-          path: $RUNNER_WORKSPACE/build
       - name: Publish test results
         uses: actions/upload-artifact@v2
         with: 

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -15,9 +15,6 @@ jobs:
       name: Checkout repository
     - name: Get Env
       run: |
-        export cwd=$PWD
-        export build_dir=$PWD/$(mktemp -d build-$(date +%F_%H.%M.%S)-XXXXX)
-        export ACCEPT_EULA=Y
         env
         set
         uname -a
@@ -34,31 +31,33 @@ jobs:
     # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu2004-README.md
     # sudo apt-get upgrade -y # do not run upgrade on all outdated packages...
       run: |
+        export ACCEPT_EULA=Y
         sudo apt-get update
         sudo apt-get install -y ninja-build ocaml
         sudo pip3 install pygments pyyaml
     - name: Configure and build
       run: |
         echo ======{,,," Configure and build ",,,}
-        echo $build_dir
-        cd $build_dir
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
+        mkdir -pv $GITHUB_WORKSPACE/../build
+        cd $GITHUB_WORKSPACE/../build
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF $GITHUB_WORKSPACE
         ninja
     - name: Run all tests
       run: |
         echo ======{,,," Run all tests ",,,}
-        mkdir -pv $build_dir/tests && cd $build_dir
-        ninja check-all 2>&1 | tee $build_dir/tests/check-all.log
+        mkdir -pv $GITHUB_WORKSPACE/../tests
+        cd $GITHUB_WORKSPACE/../build/
+        ninja check-all 2>&1 | tee $GITHUB_WORKSPACE/../tests/check-all.log
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v2
       with: 
         name: Ubuntu_build
-        path: $build_dir
-    # - name: Publish test results
-    #   uses: actions/upload-artifact@v2
-    #   with: 
-    #     name: Ubuntu_tests
-    #     path: $build_dir/tests
+        path: $GITHUB_WORKSPACE/../build
+    - name: Publish test results
+      uses: actions/upload-artifact@v2
+      with: 
+        name: Ubuntu_tests
+        path: $GITHUB_WORKSPACE/../tests
 
   build_macOS:
     name: macOS build 
@@ -69,9 +68,6 @@ jobs:
         name: Checkout repository
       - name: Get Env
         run: |
-          export cwd=$PWD
-          export build_dir=$PWD/$(mktemp -d build-$(date +%F_%H.%M.%S)-XXXXX)
-          export ACCEPT_EULA=Y
           env
           set
           uname -a
@@ -82,6 +78,7 @@ jobs:
           ls -kahl
       - name: Install ninja and ocaml
         run: |
+          export ACCEPT_EULA=Y
           brew install ninja ocaml
           pip3 install pygments pyyaml
           export CC=$(which clang)
@@ -89,22 +86,23 @@ jobs:
       - name: Configure and build
         run: |
           echo ======{,,," Configure and build ",,,}
-          echo $build_dir
-          cd $build_dir
-          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
+          mkdir -pv $GITHUB_WORKSPACE/../build
+          cd $GITHUB_WORKSPACE/../build
+          cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF $GITHUB_WORKSPACE
           ninja
       - name: Run all checks
         run: |
           echo ======{,,," Run all tests ",,,}
-          mkdir -pv $build_dir/tests && cd $build_dir
-          ninja check-all 2>&1 | tee $build_dir/tests/check-all.log
+          mkdir -pv $GITHUB_WORKSPACE/../tests
+          cd $GITHUB_WORKSPACE/../build
+          ninja check-all 2>&1 | tee $GITHUB_WORKSPACE/../tests/check-all.log
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v2
         with: 
           name: macOS_build
-          path: $build_dir
-      # - name: Publish test results
-      #   uses: actions/upload-artifact@v2
-      #   with: 
-      #     name: macOS_tests
-      #     path: $build_dir/tests
+          path: $GITHUB_WORKSPACE/../build
+      - name: Publish test results
+        uses: actions/upload-artifact@v2
+        with: 
+          name: macOS_tests
+          path: $build_dir/tests

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -15,6 +15,9 @@ jobs:
       name: Checkout repository
     - name: Get Env
       run: |
+        export cwd=$PWD
+        export build_dir=$PWD/$(mktemp -d build-$(date +%F_%H.%M.%S)-XXXXX)
+        export ACCEPT_EULA=Y
         env
         set
         uname -a
@@ -26,9 +29,6 @@ jobs:
         free -h
         df -h
         ls -kahl
-        export cwd=$PWD
-        export build_dir=$PWD/$(mktemp -d build-$(date +%F_%H.%M.%S)-XXXXX)
-        export ACCEPT_EULA=Y
     - name: Install ninja, ocaml, and co. 
     # actually, all but ninja should be installed - see https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#ubuntu-1804-lts
     # https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu2004-README.md
@@ -39,11 +39,14 @@ jobs:
         sudo pip3 install pygments pyyaml
     - name: Configure and build
       run: |
+        echo ======{,,," Configure and build ",,,}
+        echo $build_dir
         cd $build_dir
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
         ninja
     - name: Run all tests
       run: |
+        echo ======{,,," Run all tests ",,,}
         mkdir -pv $build_dir/tests && cd $build_dir
         ninja check-all 2>&1 | tee $build_dir/tests/check-all.log
     - name: Publish artifacts (i.e. binaries after compilation)
@@ -66,6 +69,9 @@ jobs:
         name: Checkout repository
       - name: Get Env
         run: |
+          export cwd=$PWD
+          export build_dir=$PWD/$(mktemp -d build-$(date +%F_%H.%M.%S)-XXXXX)
+          export ACCEPT_EULA=Y
           env
           set
           uname -a
@@ -74,8 +80,6 @@ jobs:
           system_profiler -timeout 30 -detailLevel basic
           df -h
           ls -kahl
-          export build_dir=$PWD/$(mktemp -d build-$(date +%F_%H.%M.%S)-XXXXX)
-          export cwd=$PWD
       - name: Install ninja and ocaml
         run: |
           brew install ninja ocaml
@@ -84,11 +88,14 @@ jobs:
           export CXX=$(which clang++)
       - name: Configure and build
         run: |
-          mkdir -pv $build_dir && cd $build_dir
+          echo ======{,,," Configure and build ",,,}
+          echo $build_dir
+          cd $build_dir
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
           ninja
       - name: Run all checks
         run: |
+          echo ======{,,," Run all tests ",,,}
           mkdir -pv $build_dir/tests && cd $build_dir
           ninja check-all 2>&1 | tee $build_dir/tests/check-all.log
       - name: Publish artifacts (i.e. binaries after compilation)

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -24,11 +24,12 @@ jobs:
         df -h
         ls -kahl
         export cwd=$PWD
+        export ACCEPT_EULA=Y
     - name: Install Ninja, CMake, and co. 
     # actually, all but ninja should be installed - see https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#ubuntu-1804-lts
+    # sudo apt-get upgrade -y # do not run upgrade on all outdated packages...
       run: |
         sudo apt-get update
-        sudo apt-get upgrade -y
         sudo apt-get install -y git curl build-essential ninja-build python python3
         mkdir -pv /opt/cmake && cd /opt/cmake
         curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
@@ -59,6 +60,7 @@ jobs:
           uname -a
           sw_vers
           xcodebuild -version
+          system_profiler -timeout 30 -detailLevel basic
           df -h
           ls -kahl
           export cwd=$PWD
@@ -69,7 +71,7 @@ jobs:
           export CXX=$(which clang++)
       - name: Configure and build
         run: |
-          mkdir -pv /opt/build && cd /opt/build
+          mkdir -pv /tmp/build && cd /tmp/build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF ${cwd:-$GITHUB_WORKSPACE}
           ninja
           ninja check-all
@@ -77,4 +79,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with: 
           name: macOS_build
-          path: /opt/build  
+          path: /tmp/build  

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_Linux:
-    name: Build binary for Ubuntu-latest
+    name: Ubuntu build
     runs-on: ubuntu-latest
     
     steps:
@@ -19,7 +19,7 @@ jobs:
         set
         uname -a
         cat /etc/*release*
-        nproc
+        echo "nproc=$(nproc)"
         free -h
         df -h
         ls -kahl
@@ -27,9 +27,9 @@ jobs:
     - name: Install Ninja, CMake, and co. 
     # actually, all but ninja should be installed - see https://help.github.com/en/articles/software-in-virtual-environments-for-github-actions#ubuntu-1804-lts
       run: |
-        apt update
-        apt upgrade -y
-        apt install -y git curl build-essential ninja-build python python3
+        sudo apt-get update
+        sudo apt-get upgrade -y
+        sudo apt-get install -y git curl build-essential ninja-build python python3
         mkdir -pv /opt/cmake && cd /opt/cmake
         curl -JL 'https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz' | tar xvz --strip-components=1 -f -
         export PATH=/opt/cmake/bin:$PATH
@@ -42,11 +42,11 @@ jobs:
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v1
       with: 
-        name: Binary for Ubuntu-latest
+        name: Ubuntu_build
         path: /opt/build       
 
   build_macOS:
-    name: Build binary for macOS
+    name: macOS build 
     runs-on: macOS-latest
 
     steps:
@@ -59,7 +59,6 @@ jobs:
           uname -a
           sw_vers
           xcodebuild -version
-          nproc
           df -h
           ls -kahl
           export cwd=$PWD
@@ -77,5 +76,5 @@ jobs:
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v1
         with: 
-          name: Binary for macOS-latest
+          name: macOS_build
           path: /opt/build  

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -45,7 +45,7 @@ jobs:
         ninja
     - name: Run all tests
       run: |
-        mkdir -pv /tmp/tests
+        mkdir -pv /tmp/tests && cd /tmp/build
         ninja check-all 2>&1 | tee /tmp/tests/check-all.log
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v1
@@ -89,7 +89,7 @@ jobs:
           ninja
       - name: Run all checks
         run: |
-          mkdir -pv /tmp/tests
+          mkdir -pv /tmp/tests && cd /tmp/build
           ninja check-all 2>&1 | tee /tmp/tests/check-all.log
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v1

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         export ACCEPT_EULA=Y
         sudo apt-get update
-        sudo apt-get install -y ninja-build ocaml
+        sudo apt-get install -y ninja-build ocaml lbzip2
         sudo pip3 install pygments pyyaml
     - name: Configure and build
       run: |
@@ -42,22 +42,23 @@ jobs:
         cd $RUNNER_WORKSPACE/build
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF $GITHUB_WORKSPACE
         ninja
+        cd .. && tar -c -I lbzip2 -f $GITHUB_WORKSPACE/github-actions-build-ubuntu-20.04.tar.bz2 ./build
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v2
       with: 
         name: Ubuntu_build
-        path: $RUNNER_WORKSPACE/build
+        path: github-actions-build-ubuntu-20.04.tar.bz2
     - name: Run all tests
       run: |
         echo ======{,,," Run all tests ",,,}
         mkdir -pv $RUNNER_WORKSPACE/tests
         cd $RUNNER_WORKSPACE/build/
-        ninja check-all 2>&1 | tee $RUNNER_WORKSPACE/tests/check-all.log
+        ninja check-all 2>&1 | tee $GITHUB_WORKSPACE/check-all-ubuntu-20.04.log
     - name: Publish test results
       uses: actions/upload-artifact@v2
       with: 
         name: Ubuntu_tests
-        path: $RUNNER_WORKSPACE/tests
+        path: check-all-ubuntu-20.04.log
 
   build_macOS:
     name: macOS build 
@@ -79,7 +80,7 @@ jobs:
       - name: Install ninja and ocaml
         run: |
           export ACCEPT_EULA=Y
-          brew install ninja ocaml
+          brew install ninja ocaml lbzip2 gnu-tar
           pip3 install pygments pyyaml
           export CC=$(which clang)
           export CXX=$(which clang++)
@@ -90,19 +91,20 @@ jobs:
           cd $RUNNER_WORKSPACE/build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF $GITHUB_WORKSPACE
           ninja
+          cd .. && tar -c -I lbzip2 -f $GITHUB_WORKSPACE/github-actions-build-macOS.tar.bz2 ./build
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v2
         with: 
           name: macOS_build
-          path: $RUNNER_WORKSPACE/build
+          path: github-actions-build-macOS.tar.bz2
       - name: Run all checks
         run: |
           echo ======{,,," Run all tests ",,,}
           mkdir -pv $RUNNER_WORKSPACE/tests
           cd $RUNNER_WORKSPACE/build
-          ninja check-all 2>&1 | tee $RUNNER_WORKSPACE/tests/check-all.log
+          ninja check-all 2>&1 | tee $GITHUB_WORKSPACE/check-all-macOS.log
       - name: Publish test results
         uses: actions/upload-artifact@v2
         with: 
           name: macOS_tests
-          path: $build_dir/tests
+          path: check-all-macOS.log

--- a/.github/workflows/build_binaries_on_release_branch_push.yml
+++ b/.github/workflows/build_binaries_on_release_branch_push.yml
@@ -38,26 +38,26 @@ jobs:
     - name: Configure and build
       run: |
         echo ======{,,," Configure and build ",,,}
-        mkdir -pv $GITHUB_WORKSPACE/../build
-        cd $GITHUB_WORKSPACE/../build
+        mkdir -pv $RUNNER_WORKSPACE/build
+        cd $RUNNER_WORKSPACE/build
         cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF $GITHUB_WORKSPACE
         ninja
     - name: Run all tests
       run: |
         echo ======{,,," Run all tests ",,,}
-        mkdir -pv $GITHUB_WORKSPACE/../tests
-        cd $GITHUB_WORKSPACE/../build/
-        ninja check-all 2>&1 | tee $GITHUB_WORKSPACE/../tests/check-all.log
+        mkdir -pv $RUNNER_WORKSPACE/tests
+        cd $RUNNER_WORKSPACE/build/
+        ninja check-all 2>&1 | tee $RUNNER_WORKSPACE/tests/check-all.log
     - name: Publish artifacts (i.e. binaries after compilation)
       uses: actions/upload-artifact@v2
       with: 
         name: Ubuntu_build
-        path: $GITHUB_WORKSPACE/../build
+        path: $RUNNER_WORKSPACE/build
     - name: Publish test results
       uses: actions/upload-artifact@v2
       with: 
         name: Ubuntu_tests
-        path: $GITHUB_WORKSPACE/../tests
+        path: $RUNNER_WORKSPACE/tests
 
   build_macOS:
     name: macOS build 
@@ -86,21 +86,21 @@ jobs:
       - name: Configure and build
         run: |
           echo ======{,,," Configure and build ",,,}
-          mkdir -pv $GITHUB_WORKSPACE/../build
-          cd $GITHUB_WORKSPACE/../build
+          mkdir -pv $RUNNER_WORKSPACE/build
+          cd $RUNNER_WORKSPACE/build
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_WARNINGS=OFF $GITHUB_WORKSPACE
           ninja
       - name: Run all checks
         run: |
           echo ======{,,," Run all tests ",,,}
-          mkdir -pv $GITHUB_WORKSPACE/../tests
-          cd $GITHUB_WORKSPACE/../build
-          ninja check-all 2>&1 | tee $GITHUB_WORKSPACE/../tests/check-all.log
+          mkdir -pv $RUNNER_WORKSPACE/tests
+          cd $RUNNER_WORKSPACE/build
+          ninja check-all 2>&1 | tee $RUNNER_WORKSPACE/tests/check-all.log
       - name: Publish artifacts (i.e. binaries after compilation)
         uses: actions/upload-artifact@v2
         with: 
           name: macOS_build
-          path: $GITHUB_WORKSPACE/../build
+          path: $RUNNER_WORKSPACE/build
       - name: Publish test results
         uses: actions/upload-artifact@v2
         with: 


### PR DESCRIPTION
See https://github.com/kramred/zapcc/actions/runs/163894986 for an example run.

Note that the test didn't finish neither or Ubuntu 20.04 nor macOS 15 – don't know what that means, I included some log output below.

Ubuntu 20.40 log:

```log
********************
Testing: 0 .. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 80.. 90.. 

1 warning(s) in tests.
Testing Time: 1458.57s
********************
Failing Tests (60):
    Clang :: CodeGen/alias.c
    Clang :: CodeGen/arm-aapcs-vfp.c
    Clang :: CodeGen/arm-abi-vector.c
    Clang :: CodeGen/arm-arguments.c
    Clang :: CodeGen/arm-float-helpers.c
    Clang :: CodeGen/arm-fp16-arguments.c
    Clang :: CodeGen/arm-homogenous.c
    Clang :: CodeGen/arm-neon-directed-rounding.c
    Clang :: CodeGen/arm-neon-fma.c
    Clang :: CodeGen/arm-neon-numeric-maxmin.c
    Clang :: CodeGen/arm-neon-vcvtX.c
    Clang :: CodeGen/arm-vector-arguments.c
    Clang :: CodeGen/armv7k-abi.c
    Clang :: CodeGen/atomic-ops-libcall.c
    Clang :: CodeGen/atomics-inlining.c
    Clang :: CodeGen/builtin-attributes.c
    Clang :: CodeGen/builtins-arm.c
    Clang :: CodeGen/c11atomics-ios.c
    Clang :: CodeGen/c11atomics.c
    Clang :: CodeGen/lanai-regparm.c
    Clang :: CodeGen/named_reg_global.c
    Clang :: CodeGen/ppc64-complex-parms.c
    Clang :: CodeGen/ppc64-complex-return.c
    Clang :: CodeGen/ppc64-vector.c
    Clang :: CodeGen/pr5406.c
    Clang :: CodeGen/renderscript.c
    Clang :: CodeGen/transparent-union.c
    Clang :: CodeGen/windows-on-arm-dllimport-dllexport.c
    Clang :: CodeGen/windows-on-arm-itanium-thread-local.c
    Clang :: CodeGenCXX/arm-cc.cpp
    Clang :: CodeGenCXX/arm.cpp
    Clang :: CodeGenCXX/clang-sections.cpp
    Clang :: CodeGenCXX/constructor-destructor-return-this.cpp
    Clang :: CodeGenCXX/copy-constructor-elim-2.cpp
    Clang :: CodeGenCXX/debug-info-class.cpp
    Clang :: CodeGenCXX/devirtualize-virtual-function-calls.cpp
    Clang :: CodeGenCXX/empty-nontrivially-copyable.cpp
    Clang :: CodeGenCXX/fp16-mangle.cpp
    Clang :: CodeGenCXX/homogeneous-aggregates.cpp
    Clang :: CodeGenCXX/microsoft-abi-sret-and-byval.cpp
    Clang :: CodeGenCXX/runtimecc.cpp
    Clang :: CodeGenCXX/stack-reuse-miscompile.cpp
    Clang :: CodeGenCXX/stack-reuse.cpp
    Clang :: CodeGenObjC/arm-atomic-scalar-setter-getter.m
    Clang :: CodeGenObjC/nsvalue-objc-boxable-ios-arc.m
    Clang :: CodeGenObjC/nsvalue-objc-boxable-ios.m
    Clang :: CodeGenOpenCL/atomic-ops-libcall.cl
    Clang :: Driver/cross-linux.c
    Clang :: Driver/cuda-detect-path.cu
    Clang :: Driver/riscv32-toolchain.c
    Clang :: Headers/stdarg.cpp
    LLVM :: Bindings/Go/go.test
    LLVM :: CodeGen/Mips/Fast-ISel/fastalloca.ll
    LLVM :: CodeGen/Mips/Fast-ISel/fastcc-miss.ll
    LLVM :: CodeGen/Mips/Fast-ISel/memtest1.ll
    LLVM :: CodeGen/Mips/Fast-ISel/mul1.ll
    LLVM :: CodeGen/Mips/Fast-ISel/sel1.ll
    LLVM :: CodeGen/Mips/call-optimization.ll
    LLVM :: DebugInfo/Mips/delay-slot.ll
    lit :: unittest-adaptor.py

  Expected Passes    : 35107
  Expected Failures  : 162
  Unsupported Tests  : 985
  Unexpected Failures: 60

```

macOS log:

```log
********************
Testing: 0 .. 10.. 20.. 30.. 40.. 50.. 60.. 70.. 80.. 90.. 

1 warning(s) in tests.
Testing Time: 835.29s
********************
Failing Tests (19):
    LLVM-Unit :: Support/DynamicLibrary/./DynamicLibraryTests/DynamicLibrary.Overload
    LLVM-Unit :: Support/DynamicLibrary/./DynamicLibraryTests/DynamicLibrary.Shutdown
    Clang :: Driver/cross-linux.c
    Clang :: Driver/cuda-detect-path.cu
    Clang :: Driver/fuse-ld.c
    Clang :: Driver/riscv32-toolchain.c
    Clang :: Index/crash-recovery-modules.m
    Clang :: zapcc/multi/reuse-failed-dir/reuse-failed-dir.lst
    Clang :: zapcc/single/2regression/ast-dump-two-files.cpp
    Clang :: zapcc/single/2regression/guard-variable.cpp
    LLVM :: Bindings/Go/go.test
    LLVM :: CodeGen/Mips/Fast-ISel/fastalloca.ll
    LLVM :: CodeGen/Mips/Fast-ISel/fastcc-miss.ll
    LLVM :: CodeGen/Mips/Fast-ISel/memtest1.ll
    LLVM :: CodeGen/Mips/Fast-ISel/mul1.ll
    LLVM :: CodeGen/Mips/Fast-ISel/sel1.ll
    LLVM :: CodeGen/Mips/call-optimization.ll
    LLVM :: DebugInfo/Mips/delay-slot.ll
    lit :: unittest-adaptor.py

  Expected Passes    : 35154
  Expected Failures  : 164
  Unsupported Tests  : 978
  Unexpected Failures: 19
```